### PR TITLE
Improve basic_pipeline headers.

### DIFF
--- a/basic_pipeline/01.0_Introduction.md
+++ b/basic_pipeline/01.0_Introduction.md
@@ -3,7 +3,7 @@ In this tutorial, we will create our very own Membrane Framework consisting of o
 Despite the fact that the multimedia processing task we will be facing will be really simple, we will need to deal with some problems occurring in real-life scenarios.
 At the same time, we will make ourselves comfortable with some concepts of multimedia streaming as well as get in touch with the nomenclature used in this field. 
 Prepare for an adventure! 
-# Environment preparation
+## Environment preparation
 In order to be able to proceed with the tutorial, you need to have Elixir installed: [How to install Elixir](https://elixir-lang.org/install.html).
 We assume, that you are at least slightly familiar with that language - if that is not true, we would like to strongly encourage you to take a look at the [official Elixir tutorial](https://elixir-lang.org/getting-started/introduction.html).
 Once you are ready with the Elixir, you can get the project template we have prepared for you:
@@ -17,7 +17,7 @@ As you can see, the template's code is put on the `template/start` branch of the
 In the repository, there is also a `template/end` branch, where you can find the completed template.
 If you find yourself lost during the tutorial feel free to check the implementation proposed by us, put on this branch.
 
-# Use Case
+## Use Case
 Imagine that there is a conversation occurring between two peers and the chat is based on a question-answer scheme.
 Each of the peers sends its part of the conversation (that means - the first peer sends questions and the second peers sends the answers to them). We refer to each sentence sent by the peers as a **frame**.
 However, due to network limitations each frame sent by the peers is fragmented since only a few chars can be sent at the same time - that means, a single frame is sent as a sequence of **packets**. 
@@ -26,7 +26,7 @@ in which the data needs to be fragmented in order to be transmitted - but we dec
 Each packet consists of the *header* (describing where the particular bunch of characters it transports should be put) and the *body* - aforementioned  bunch of characters.
 Below you can see an exemplary frame sent by one peer to the other. It gets fragmented into multiple packets, which later on are sent via the network (during that process their order will probably get messed). On the second peer's side, the packets get assembled into the original frame.
 ![Example Chat](assets/images/example_chat.drawio.png)
-## Packet format
+### Packet format
 Here is how each packet looks like:
 ```
 [seq:<sequence_id>][frameid:<frame_id>][timestamp:<timestamp>]<text>
@@ -37,7 +37,7 @@ where:
 + timestamp - a number indicating a time at which a given sentence was said. Timestamp describes the order of the frames from both peers. 
 + text - the proper body of the packet, in our case - a bunch of characters which could be sent in a single packet.
 
-## Packets generator
+### Packets generator
 We have equipped you with the tool which produces the packets in the format described previously, based on the input conversation. You can use it as a mix task, by typing:
 ```
 mix generate_input --packetsPerFrame <packets_per_frame> <input_file_path>
@@ -55,7 +55,7 @@ Below you can see the steps which are taken during the input files generation:<b
 ![Example Input](assets/images/example_input.drawio.png)
 Create a file with your own input conversation occurring between two speakers or use the `input.txt` file where we have provided you such a conversation. Generate the files containing packets, with the use of `mix generate_input` task.
 
-# Task description
+## Task description
 By the end of this chapter you should have generated the files containing packets (i.e. `input.A.txt` and `input.B.txt`).
 
 Your task is to assemble the conversation together from those packets. In the first step you will reproduce the sentences sent by each of the peers by gathering the words sent in packets in the appropriate order. In multimedia processing, we would say that you need to reproduce the *frame* out of the *transport layer packets*. Later on you need to put those *frames* in the correct order, producing the *raw data stream*.

--- a/basic_pipeline/02.0_SystemArchitecture.md
+++ b/basic_pipeline/02.0_SystemArchitecture.md
@@ -1,3 +1,4 @@
+# System architecture
 Once we know what should be done, let's start thinking how should our system look like!
 
 First, let's get familiar with some terms. In the Membrane Framework, there is a concept of the `pipeline` which consists of multiple `elements`. Elements are linked with the use of the `pads`, which can be input pads or output pads.
@@ -11,11 +12,11 @@ One might wonder when does the event of the buffers being sent occurs - well, it
 If the pad works in the *pull* mode, the buffer is sent when it is demanded by the succeeding element in the pipeline.
 Otherwise, the pad works in the *push* mode, which means that it is pushing the buffers once they are ready, independently from the fact if the following elements want (and are capable of processing) it.
 In our pipeline, all the pads will work in the *pull* mode, which inducts a flow control by a [backpressure](https://medium.com/@jayphelps/backpressure-explained-the-flow-of-data-through-software-2350b3e77ce7) mechanism.
-# Scheme
+## Scheme
 ![Pipeline scheme](assets/images/basic_pipeline.png) <br>
 As you can see, our pipeline will consist of two twin branches, one per each of the peers. The branches will be merged with the `Mixer` element and the result produced by this element will be put in the file with the `Sink` elements. 
 Here you can find the description of the particular elements of the system.
-# Elements description
+## Elements description
 + **Source** - that element is responsible for reading the list of packets from the file. 
 + **Ordering Buffer** - this element is responsible for reordering the packets based on their sequence id. The most important part of this element is the buffer, within which there is a place for all the packets, identified by the packet's sequence id. Once the new packet is received, it is placed in the proper place in the buffer, depending on the sequence id. If there is a consistent part of packets "at the bottom of the buffer" (which means - packets with the subsequent sequence ids, which haven't already been sent yet), then this part is sent via the output pad. That is how we make sure that the next element will receive elements sorted by the sequence id. 
 Below you can see how the Ordering Buffer is expected to work, once the message "How are you doing?" will be sent in the four packets, each with one word, and received in the following order: (are, you, how, doing?) <br>

--- a/basic_pipeline/03.0_Source.md
+++ b/basic_pipeline/03.0_Source.md
@@ -1,3 +1,4 @@
+# Source
 Let's get to the code! 
 We will start where all the pipelines start - with the `Source` element. 
 Since this will be the first element we implement, we need to find out something more about how the Membrane Framework's elements should be implemented and some concepts associated with them.
@@ -11,7 +12,7 @@ the updated state (which later on will be passed to the next invoked callback).
 Take your time and read about the possible actions which can be requested to be performed while returning from the callback. Their usage is crucial for the pipeline to work.
 
 As you can judge based on the structure of the project, all the elements will be put in the `lib/elements` directory. Therefore there is a place where `Source.ex` with the `Basic.Elements.Source` module's definition should be placed.
-# What makes our module a Membrane Framework's element?
+## What makes our module a Membrane Framework's element?
 Let's start with specifying that our module will implement the `Membrane.Source` behavior as well as alias the modules which will be used later in the module's code:
 ###### **`lib/elements/Source.ex`**
 ```Elixir
@@ -23,7 +24,7 @@ defmodule Basic.Elements.Source do
 end
 
 ```
-# Pads and options
+## Pads and options
 Later on, we will make use of [macros](https://elixir-lang.org/getting-started/meta/macros.html) defined in the `Membrane.Source` module:
 ###### **`lib/elements/Source.ex`**
 ```Elixir
@@ -46,7 +47,7 @@ and the `:location` option will be passed during the construction of the element
 The second macro, `def_output_pad`, lets us define the output pad. The pad name will be `:output` (which is a default name for the output pad). The second argument of the macro describes the `:caps` - which is the type of data sent through the pad. As the code states, we want to send data in `Basic.Formats.Packet` format.
 What's more, we have specified that the `:output` pad will work in the `:pull` mode. 
 You can read more on the pad specification [here](https://hexdocs.pm/membrane_core/Membrane.Pad.html#t:common_spec_options_t/0).
-# Initialization of the element
+## Initialization of the element
 Let's define our first callback! Why not start with [`handle_init/1`](https://hexdocs.pm/membrane_core/Membrane.Element.Base.html#c:handle_init/1), which gets called once the element is created?
 ###### **`lib/elements/Source.ex`**
 ```Elixir
@@ -67,11 +68,11 @@ end
 
 As said before, `handle_init/1` expects a structure with the previously defined parameters to be passed as an argument.
 All we need to do there is to initialize the state - our state will be in a form of a map, and for now on we will put there a `location` (a path to the input file) and the `content`, where we will be holding packets read from the file, which haven't been sent yet. For now, the content is set to nil as we haven't read anything from the input file yet.
-<!---TIP
-You might also wonder what is the purpose of the `@impl true` specifier, put just above the function signature - this is simply a way to tell the compiler 
-that the function defined below is about to be a callback. If we have misspelled the function name (or provided a wrong arguments list), we will be informed in the compilation time.)
--->
-# Playback states
+> ### TIP 
+> You might also wonder what is the purpose of the `@impl true` specifier, put just above the function signature - this is simply a way to tell the compiler 
+> that the function defined below is about to be a callback. If we have misspelled the function name (or provided a wrong arguments list), we will be informed in the compilation time.
+
+## Playback states
 Before going further you should stop for the moment and read about the [playback states](https://hexdocs.pm/membrane_core/Membrane.Element.Action.html#t:playback_change_t/0) in which the Pipeline (and therefore - its elements) can be. Generally speaking, there are three playback states: **stopped**, **prepared**, and **playing**. The transition between the states can happen automatically or as a result of a user's explicit action.
 The callbacks we are about to implement will be called once the transition between playback states occurs.
 
@@ -100,7 +101,7 @@ In the case of the first callback, `handle_stopped_to_prepared/2`, what we do is
 Then we split the content of the file to get the particular packets and save the list of those packets in the state of the element.
 An interesting thing here is the action we are returning - the `:caps` action. That means that we want to transmit the information about the supported caps through the `output` pad, to the next element in the pipeline. In the [chapter 3.1](03.1_Caps.md) you will find out more about caps and formats and learn why it is required to do so.
 The second callback, `handle_prepared_to_stopped`, defines the behavior of the Source element while we are stopping the pipeline. What we want to do is to clear the content buffer in the state of our element.
-# Demands
+## Demands
 Before going any further let's stop for a moment and talk about the demands. Do you remember, that the `:output` pad is working in the pulling mode? That means that the succeeding element have to ask the Source element for the data to be sent and our element has to take care of keeping that data in some kind of buffer until it is requested. 
 Once the succeeding element requests for the data, the `handle_demand/4` callback will be invoked - therefore it would be good for us to define it:
 ```Elixir

--- a/basic_pipeline/03.1_Caps.md
+++ b/basic_pipeline/03.1_Caps.md
@@ -1,7 +1,7 @@
-# Introduction
+# Caps
 We owe you something...and we would like to pay it back as soon as possible!
 As promised in the [3rd chapter](03.0_Source.md), we will talk more about the concept of caps - which in fact we have used in the previous chapter, but which weren't described sufficiently.
-# What are caps?
+## What are caps?
 Caps (an abbreviation of the *capabilities*) is a concept allowing us to define what kind of data is flowing through the pad. 
 In the Membrane Framework's nomenclature, we say, that we define a caps specification for a given element.
 
@@ -16,7 +16,7 @@ Caps help us find out if the given elements are capable to communicate with each
 
 Caps help us define a contract between elements and prevent us from connecting incompatible elements. That is why it is always better to define precise caps rather than using caps of type `:any`.
 
-# When the caps are compatible?
+## When the caps are compatible?
 A comparison between caps is made when the pads are connected. Due to freedom in defining the type, the comparison is not that straightforward. It would be good for a responsible Membrane's element architect to be aware of how the caps are compared. You can refer to the implementation of the caps matcher, available [here](https://github.com/membraneframework/membrane_core/blob/82d6162e3df94cd9abc508c58bc0267367b02d58/lib/membrane/caps/matcher.ex#L124)...or follow on this chapter, and learn it by an example.
 Here is how you define a caps specification:
 1. First you need to specify the format module
@@ -60,7 +60,7 @@ For all the filter elements, `handle_caps/4` has a default implementation, which
 However, if your filter is changing the format of data being sent, it should override the implementation of that callback to prevent caps flying through it, and send the proper caps via the output pads. 
 
 For the source element, it is necessary to send the caps as in each pipeline the source is the first element - caps wouldn't flow through the pipeline if the source element wouldn't have sent them. Sending can be done in the `handle_stopped_to_prepared/2` callback.
-# Example
+## Example
 Imagine a pipeline, which starts with the source producing a video, which is then passed to the filter, responsible for reducing the quality of that video if it is too high.
 For the source element, we should have the `:output` pads caps which would allow us to send video in the higher and in the lower quality. The same caps should be specified on the input of the filter element. However, the caps on the output of the filter should accept only video in the lower quality.
 Here is the definition of the source element:

--- a/basic_pipeline/04.0_Formats.md
+++ b/basic_pipeline/04.0_Formats.md
@@ -1,3 +1,4 @@
+# Formats
 Since we have already discussed what caps are and how to use them, let's make use of them in our project!
 The first thing to do is to define modules responsible for describing the formats used in our pipeline.
 We will put them in a separate directory - `lib/formats`. Let's start with the format describing the packets:

--- a/basic_pipeline/05.0_OrderingBuffer.md
+++ b/basic_pipeline/05.0_OrderingBuffer.md
@@ -1,3 +1,5 @@
+# Ordering Buffer
+
 In this chapter we will deal with the next element in our pipeline - the Ordering Buffer.
 As stated in the [chapter about the system architecture](02.0_SystemArchitecture.md), this element is responsible for ordering the incoming packets, based on their sequence id.
 Because Ordering Buffer is a filtering element, we need to specify both the input and the output pads:
@@ -86,22 +88,22 @@ Therefore we have defined the regex description as:
 ~r/^\[seq\:(?<seq_id>\d+)\](?<data>.*)$/
 ```
 
-<!---TIP
-+ `~r/.../` stands for the `sigil_r/1` [sigil](https://elixir-lang.org/getting-started/sigils.html)
-+ `^` describes the beginning of the input
-+ `\[` stands for the opening square bracket ('[') at the beginning is required to escape the char since the plain '[' has a special meaning in the regex syntax
-+ `seq` is a sequence of 's', 'e', 'q' characters (we need to adjust our regex description to match the header of the packet)
-+ `\:` stands for the ':' character (we also need to escape that character since it is meaningful in the regex's syntax)
-+ `(?<seq_id>\d+)` allows us to define a named capture - later one, once we use the `Regex.named_captures/2`, we will retrieve the map with 'seq_id' key and the corresponding value equal to the string described by the `\d+` 'partial' regex (which means - one or more occurrences of a decimal). Generally speaking, a named capture can be specified with the following structure: `(?<key>regex)` where `regex` is a regex description.
-+ `\]` is the escaped closing square bracket character
-+ `(?<data>.*)` is a named capture description that allows us to get the value of a `.*` regex (any character no or any number of times) under a `data` key.
-+ `$` stands for the end of the input
+> ### TIP - How to read the regex?
+> + `~r/.../` stands for the `sigil_r/1` [sigil](https://elixir-lang.org/getting-started/sigils.html)
+> + `^` describes the beginning of the input
+> + `\[` stands for the opening square bracket ('[') at the beginning is required to escape the char since the plain '[' has a special meaning in the regex syntax
+> + `seq` is a sequence of 's', 'e', 'q' characters (we need to adjust our regex description to match the header of the packet)
+> + `\:` stands for the ':' character (we also need to escape that character since it is meaningful in the regex's syntax)
+> + `(?<seq_id>\d+)` allows us to define a named capture - later one, once we use the `Regex.named_captures/2`, we will retrieve the map with 'seq_id' key and the corresponding value equal to the string described by the `\d+` 'partial' regex (which means - one or more occurrences of a decimal). Generally speaking, a named capture can be specified with the following structure: `(?<key>regex)` where `regex` is a regex description.
+> + `\]` is the escaped closing square bracket character
+> + `(?<data>.*)` is a named capture description that allows us to get the value of a `.*` regex (any character no or any number of times) under a `data` key.
+> + `$` stands for the end of the input
 
 The result of `Regex.named_captures/2` applied to that regex description and the exemplary packet should be following:
 ```Elixir
 {"seq_id"=>7, "data"=>"[frameid:2][timestamp:3]data"}
 ```
--->
+
 Once we unzip the header of the packet in the `handle_process/4` callback, we can put the incoming packet in the `ordered_packets` list and sort that list. Due to the fact, that elements of this list are tuples, whose first element is a sequence id (a value that is unique), the list will be sorted based on the sequence id.
 We also get the sequence id of the first element in the updated `ordered_packets` list.
 

--- a/basic_pipeline/05.1_Redemands.md
+++ b/basic_pipeline/05.1_Redemands.md
@@ -1,3 +1,4 @@
+# Redemands
 Redemanding is a very convenient mechanism that helps you, the Membrane Developer, stick to the DRY (Don't Repeat Yourself) rule.
 Generally speaking, it can be used in two situations:
 + in the source elements
@@ -5,7 +6,7 @@ Generally speaking, it can be used in two situations:
 
 To comprehensively understand the concept behind redemanding, you need to be aware of the typical control flow which occurs in the Membrane's elements - which you could have seen in the elements we have already defined. 
 
-# In Source elements
+## In Source elements
 In the source elements, there is a "side-channel", from which we can receive data. That "side-channel" can be, as in the exemplary pipeline we are working on, in form of a file, from which we are reading the data. In real-life scenarios it could be also, i.e. an RTP stream received via the network. Since we have that "side-channel", there is no need to receive data via the input pad (that is why we don't have it in the source element, do we?).
 The whole logic of fetching the data can be put inside the `handle_demand/5` callback - once we are asked to provide the buffers, the `handle_demand/5` callback gets called and we can provide the desired number of buffers from the "side-channel", inside the body of that callback. No processing occurs here - we get asked for the buffer and we provide the buffer, simple as that.
 The redemand mechanism here lets you focus on providing a single buffer in the `handle_demand/5` body - later on, you can simply return the `:redemand` action and that action will invoke the `handle_demand/5` once again, with the updated number of buffers which are expected to be provided. Let's see it in an example - we could have such a `handle_demand/5` definition (and it wouldn't be a mistake!):
@@ -36,7 +37,7 @@ end
 ```
 
 
-# In Filter elements
+## In Filter elements
 In the filter element, the situation is quite different. 
 Since the filter's responsibility is to process the data sent via the input pads and transmit it through the output pads, there is no 'side-channel' from which we could take data. That is why in normal circumstances you would transmit the buffer through the output pad in the `handle_process/4` callback (which means - once your element receives a buffer, you process it, and then you 'mark' it as ready to be output with the `:buffer` action). When it comes to the `handle_demand/5` action on the output pad, all you need to do is to demand the appropriate number of buffers on the element's input pad. The behavior which is easy to specify when we exactly know how many input buffers correspond to the one output buffer (recall the situation in the Depayloader of our pipeline, where we *a priori* knew, that each output buffer (frame) consists of a given number of input buffers (packets), becomes impossible to define if the output buffer might be a combination of a discretionary set number of input buffers. However, we have dealt with an unknown number of required buffers in the OrderingBuffer implementation, where we didn't know how many input buffers do we need to demand to fulfill the missing spaces between the packets ordered in the list. How did we manage to do it?
 We simply used the `:redemand` action! In case there was a missing space between the packets, we returned the `:redemand` action, which immediately called the `handle_demand/5` callback (implemented in a way to request for a buffer on the input pad). The fact, that that callback invocation was immediate, which means - the callback was called synchronously, right after returning from the `handle_process/4` callback, before processing any other message from the element's mailbox - might be crucial in some situations, since it makes us sure, that the demand will be done before handling any other event.

--- a/basic_pipeline/06.0_Depayloader.md
+++ b/basic_pipeline/06.0_Depayloader.md
@@ -1,3 +1,4 @@
+# Depayloader
 Since we have packets put in order by the Ordering Buffer, we can assemble them into the original frames.
 The Depayloader is an element responsible for this task. Specifically speaking, it unpacks the payload from the packets -
 and that is why it's called 'depayloader'.

--- a/basic_pipeline/07.0_Mixer.md
+++ b/basic_pipeline/07.0_Mixer.md
@@ -1,3 +1,4 @@
+# Mixer
 Here comes the mixer - an element responsible for mixing two streams of frames, coming from two different sources. 
 Once again we start with defining the initialization options and the pads of both types:
 ###### **`lib/elements/Mixer.ex`**

--- a/basic_pipeline/08.0_Sink.md
+++ b/basic_pipeline/08.0_Sink.md
@@ -1,8 +1,9 @@
+# Sink
 The sink is the last element in our pipeline, designed to store the data processed by the pipeline. 
 In contrast to the filter elements, it won't have any output pad - that is why we need to make our element `use Membrane.Sink` and define the input pad only.
 Since we want to parameterize the usage of that element, it will be good to define the options structure, so that we can specify the path to the file where the output should be saved. This stuff is done in the code snippet below:
+###### **`lib/elements/Sink.ex`**
 ```Elixir
-#FILE lib/elements/Sink.ex
 
 defmodule Basic.Elements.Sink do
  @moduledoc """
@@ -18,9 +19,9 @@ defmodule Basic.Elements.Sink do
 end
 ```
 
-No surprises there - now we need to specify the element's behavior by defining the relevant callbacks! 
+No surprises there - now we need to specify the element's behavior by defining the relevant callbacks!
+###### **`lib/elements/Sink.ex`**
 ```Elixir
-#FILE lib/elements/Sink.ex
 
 defmodule Basic.Elements.Sink do
  ...
@@ -37,8 +38,8 @@ end
 We have started with `handle_init/1`, where we are initializing the state of the element (we need to store the path to the output files).
 
 Later on, we can specify the `handle_prepared_to_playing/2` callback - this callback gets called once the pipeline gets in the `:playing` state - that is a moment when we can demand the buffers for the first time (since the pipeline is already prepared to work):
+###### **`lib/elements/Sink.ex`**
 ```Elixir
-#FILE lib/elements/Sink.ex
 
 defmodule Basic.Elements.Sink do
  ...
@@ -51,8 +52,8 @@ end
 ```
 
 There is only one more callback that needs to be specified - `handle_write/4`, which get's called once there are some buffers that can be processed (which means, that there are buffers to be written since there are no output pads through which we could be transmitting these buffers):
+###### **`lib/elements/Sink.ex`**
 ```Elixir
-#FILE lib/elements/Sink.ex
 
 defmodule Basic.Elements.Sink do
  ...

--- a/basic_pipeline/09.0_Pipeline.md
+++ b/basic_pipeline/09.0_Pipeline.md
@@ -1,10 +1,11 @@
+# Pipeline
 The time has come to assemble all the bricks together and create the pipeline!
 This task is really easy since the Membrane Framework provides a sort of DSL (*Domain Specific Language*) which allows you to link the prefabricated components together.
 In many real-life scenarios, this part would be the only thing you would need to do since you can take advantage of plenty of ready components (in form of elements and bins) which are available as a part of the Membrane Framework. For now, we will create the pipeline out of the elements we have created during that tutorial!
-# Defining the pipeline
+## Defining the pipeline
 The pipeline is another behavior introduced by the Membrane Framework. To make the module a pipeline, we need to make it `use Membrane.Pipeline`. That is how we will start our implementation of the pipeline module, in the `lib/Pipeline.ex` file:
+###### **`lib/Pipeline.ex`**
 ```Elixir
-# FILE: lib/Pipeline.ex
 
 defmodule Basic.Pipeline do
 
@@ -15,8 +16,9 @@ end
 
 You could have guessed - all we need to do now is to describe the desired behavior by implementing the callbacks! In fact, the only callback we want to implement if the pipeline is the `handle_init/1` callback, called once the pipeline is initialized - of course, there are plenty of other callbacks which you might find useful while dealing with a more complex task. You can read about them (here)[https://hexdocs.pm/membrane_core/Membrane.Pipeline.html#callbacks].
 Please add the following callback signature to our `Basic.Pipeline` module:
+###### **`lib/Pipeline.ex`**
 ```Elixir
-# FILE: lib/Pipeline.ex
+
 defmodule Basic.Pipeline do
  ... 
  @impl true
@@ -28,7 +30,7 @@ end
 ```
 As you can see, we can initialize the pipeline with some options, but in our case, we do not need them.
 
-# Supervising and children-parent relationship
+## Supervising and children-parent relationship
 In Elixir's actor model, derived from the Erlang programming language (as well as in many other implementations of the actor system) there is a concept of the actors supervising each other. 
 In case of the actor failing due to an error it is its supervisor's responsibility to deal with that fact - either by stopping that actor, restarting it, or performing some other action.
 With such a concept in mind, it's possible to create reliable and fault-tolerant actor systems.
@@ -45,8 +47,9 @@ Please stop for a moment and read about the [`Membrane.ParentSpec`](https://hexd
 We will wait for you and once you are ready, we will define our own children and links ;)
 
 Let's start with defining what children we need inside the `handle_init/1` callback! If you have forgotten what structure we want to achieve please refer to the [2nd chapter](02.0_SystemArchitecture.md) and recall what elements we need inside of our pipeline.
+###### **`lib/Pipeline.ex`**
 ```Elixir
-# FILE: lib/Pipeline.ex
+
 
 @impl true
 def handle_init(_opts) do
@@ -68,8 +71,8 @@ Remember to pass the desired file paths in the `:location` option!
 We have just created the map, which keys are in the form of atoms that describe each of the children and the values are particular module built-in structures (with all the required fields passed).
 
 Now we have a `children` map which we will use to launch the processes. But the Membrane needs to know how those children elements are connected (and, in fact, how the pipeline is defined!). Therefore let's create a `links` list with the description of the links between the elements:
+###### **`lib/Pipeline.ex`**
 ```Elixir
-# FILE: lib/Pipeline.ex
 
 def handle_init(_opts) do
  ...
@@ -89,8 +92,8 @@ Each pipeline's "branch" starts with the `link/1` which takes as an argument an 
 `via_in/1` allows specifying an input pad with a given name. Since in a mixer there are two input pads (`:first_input` and `:second_input`, defined in `Basic.Elements.Mixer` module with `def_input_pad` and `def_output_pad` macros), we need to distinguish between them while linking the elements. 
 Of course, there is also a `via_out/1` function, which is used to point the output pad with the given identifier, but there was no need to use it. 
 In the case of other elements we do not need to explicitly point the desired pads since we are taking advantage of the default pads name - `:input` for the input pads and `:output` for the output ones (see what names we have given to our pads in the elements other than the mixer!). However, we could rewrite the following `links` definitions and explicitly specify the pad names:
+###### **`lib/Pipeline.ex`**
 ```Elixir
-# FILE: lib/Pipeline.ex
 
 def handle_init(_opts) do
  ...
@@ -106,8 +109,8 @@ end
 ```
 
 That's almost it! All we need to do is to return a proper tuple from the `handle_init/1` callback, with the `:spec` action defined:
+###### **`lib/Pipeline.ex`**
 ```Elixir
-# FILE: lib/Pipeline.ex
 
 def handle_init(_opts) do
  ...

--- a/basic_pipeline/10.0_DynamicPads.md
+++ b/basic_pipeline/10.0_DynamicPads.md
@@ -1,9 +1,11 @@
+# Dynamic pads
 The solution we have implemented along the tutorial is complete. 
 However, it has at least one downside - it is definitely not easily extendable.
 What if we needed to support mixing streams coming from three different speakers in the conversation?
 Well, we would need to add another input pad in the Mixer, for instance - `:third_input` pad, and then update our Pipeline definition:
+
+###### **`lib/Pipeline.ex`**
 ```Elixir
-#FILE: lib/Pipeline.ex
 
 @impl true
 def handle_init(_opts) do
@@ -29,15 +31,15 @@ But what if there were 4 people in the conversation? Adding another pad to the M
 And what if the number of speakers was unknown at the moment of the compilation? Then we wouldn't be able to predefine the pads in the Mixer.
 The Membrane Framework comes with a solution for this sort of problem - and the solution is called: **dynamic pads**. 
 
-# What is the idea behind the dynamic pads?
+## What is the idea behind the dynamic pads?
 Well, the idea is quite simple! Instead of specifying a single pad with a predefined name (*static pad*) as we did in all the modules before, we specify, that we want **a set of pads** of a given type. Initially, that set will be empty, but with each link created in the parent's child specification, the element will be informed, that the pad of a given type was added - and therefore it will be able to invoke the `handle_pad_added/3` callback.
 
-# The Mixer revisited
+## The Mixer revisited
 Let's try to use dynamic pads for the input in the Mixer!
 The very first thing we need to do is to use the `def_input_pads` appropriately.
+###### **`lib/elements/Mixer.ex`**
 ```Elixir
 
-#FILE: lib/elements/Mixer.ex
 ...
 def_input_pad(:input, demand_unit: :buffers, availability: :on_request, caps: {Basic.Formats.Frame, encoding: :utf8})
 ...
@@ -46,9 +48,9 @@ def_input_pad(:input, demand_unit: :buffers, availability: :on_request, caps: {B
 We have added the [`availability: :on_request` option](https://hexdocs.pm/membrane_core/Membrane.Pad.html#t:availability_t/0), which allows us to define the set of dynamic pads, identified as `:input`.
 
 No more do we have the `:first_input` and the `:second_input` pads defined, so we do not have the tracks corresponding to them either! Let's update the `handle_init/1` callback:
+###### **`lib/elements/Mixer.ex`**
 ```Elixir
 
-#FILE: lib/elements/Mixer.ex
 ...
 @impl true
 def handle_init(_options) do
@@ -60,9 +62,8 @@ end
 ```
 Tracks map is initially empty since there are no corresponding pads.
 The next thing we need to do is to implement the `handle_pad_added/3` callback, which will be called once the pipeline starts, with some links pointing to dynamic pads:
-
+###### **`lib/elements/Mixer.ex`**
 ```Elixir
-#FILE: lib/elements/Mixer.ex 
 
 ...
 @impl true
@@ -76,11 +77,11 @@ end
 Once a pad is created, we add a new `Track` to the tracks map, with the pad being its key.
 That's it! Since we have already designed the Mixer in a way it is capable of serving more tracks, there is nothing else to do.
 
-# Updated pipeline
+## Updated pipeline
 Below you can find the updated version of the pipeline's `handle_init/1` callback:
 
+###### **`lib/Pipeline.ex`**
 ```Elixir
-#FILE: lib/elements/Mixer.ex 
 
 ...
 @impl true
@@ -117,7 +118,7 @@ The crucial thing was to change the plain atom name identifying the pad (like `:
 The first argument passed to that function is the name of the dynamic pad's set (in our case: `:input`, as we have defined the `:input` dynamic pads set in the Mixer element), and the second argument is a particular pad identifier.
 As you can see, we have created two `:input` pads: `:first` and `:second`. While starting the pipeline, the `handle_pad_added/3` callback will be called twice, once per each dynamic pad created.
 
-# Further actions
+## Further actions
 As an exercise, you can try to modify the `lib/Pipeline.ex` file so that to define there a pipeline consisting of three parallel branches, being mixed in a single Mixer. Later on, you can check if the pipeline works as expected, by generating the input files out of the conversation in which participate three speakers.
 
 The proposed solution can be found on the [dynamic_pads branch of the template repository](https://github.com/membraneframework/membrane_getting_started_tutorial/tree/dynamic_pads).

--- a/basic_pipeline/11.0_Tests.md
+++ b/basic_pipeline/11.0_Tests.md
@@ -1,16 +1,17 @@
+# Tests
 Even not-so-much experienced developers could have noticed that we were missing a really important part of software development - the testing. Don't worry! We are hurrying with the description of the testing framework and good practices which will allow you to write reliable tests for your Membrane system.
-# Do we need testing?
+## Do we need testing?
 Testing in terms of software engineering is no less important than functionalities programming.
 We are sure we do not need to persuade you that our pipeline, and especially its elements need testing. In fact - who wouldn't like to be sure, that changes just made in the functionalities code do not break the desired element's behavior? And all that in the matter of typing simple `mix test` command?
 In the scope of this chapter we will implement some unit tests for the elements of our pipeline. They will check the behavior of the elements in isolation.
 We will immediately jump to the code and try to experience the Membrane tests on our own.
-# Our first test
+## Our first test
 Elixir comes with a great tool for testing - [ExUnit](https://hexdocs.pm/ex_unit/ExUnit.html).
 If you have never written tests in ExUnit, feel free to stop for a moment and read about how the tests are constructed - however, ExUnit deals with tests in such a clear way that probably you will be able to see what's going on by just looking at the code snippets in the further part of this tutorial.
 We need to specify, that we will be writing only unit tests - that means, we will write tests checking the behavior of a single element, isolated from the other elements in the pipeline.
 Let's create a `test/elements/depayloader_test.exs` file and put the following code inside it:
+###### **`test/elements/depayloader_test.exs`**
 ```Elixir
-#FILE: test/elements/depayloader_test.exs
 
 defmodule DepayloaderTest do
  use ExUnit.Case 
@@ -25,8 +26,8 @@ This way we are defining a testing module with the use of the ExUnit, as well as
 The `doctest` macro checks if the given module has proper documentation (typespecs, module description etc.).
 
 We have decided to show the process of writing tests based on the depayloader - since the behavior of this element is well described and can be easily checked. Let's recall what is the responsibility of the depayloader - this element is receiving ordered packets and is about to form frames out of them. Let's check if it is doing it properly!
+###### **`test/elements/depayloader_test.exs`**
 ```Elixir
-#FILE: test/elements/depayloader_test.exs
 
 defmodule DepayloaderTest do
  ...
@@ -72,14 +73,14 @@ Finally, after the last buffer is processed (the last buffer is the buffer whose
 If no action was returned from the last `handle_process/4`, the pattern wouldn't match to the `{{:ok, actions}, _state}`, and the test would fail.
 If the assertion on the output buffer's payload wouldn't be true - the test would also fail.
 
-# The Membrane's support for tests
+## The Membrane's support for tests
 The test written above is quite simple. Probably you have noticed that what we did there was "simulating" the behavior of the Membrane's Core, in a limited, but satisfying our needs, way. During the pipeline run, it is Membrane's responsibility to invoke the callbacks and pass the updated version of the state as the argument.
 However, Membrane's Core behavior is much more complicated - if we were using some more complex mechanism (i.e. redemands), possibly we would need to simulate that behavior in a more detailed way - finally ending with the Membrane's Core in our test module.
 Such an approach scales terribly - and that is why we want to avoid it. Membrane Core's developers have given us support for testing the elements which allow us to have a simple pipeline consisting of a generic source and sink, as well as our element.
 Such a pipeline behaves just like any other pipeline in a regular working Membrane system - however, we are also given a bunch of helpful tools (like assertion macros) to check if our element has a desired business logic implemented in its behavior.
 Below we will rewrite the test we have just written, but with the support from the Membrane Framework:
+###### **`test/elements/depayloader_test.exs`**
 ```Elixir
-#FILE: test/elemets/depayloader_test.exs
 
 defmodule DepayloaderTest do
   ...
@@ -148,12 +149,11 @@ mix test
 If everything works (both the tests and the functionality's code itself), you should see a notification that the test has passed successfully, which we hope you do see!
 
 
-# Some special types of tests
+## Some special types of tests
 As you remember, Source and Sink elements act specifically different than the Filter elements - that is why they are communicating with the 'outer world', i.e. by reading the data from a file or saving the result to the file. In order to check if their behavior is desired, we cannot create a testing pipeline with generic Source and Sink, since it is a Source/Sink that we want to test.
 We will need to somehow mock the `outer environment` - let's see how this can be done, based on the example of the Source test:
-
+###### **`test/elements/source_test.exs`**
 ```Elixir
-#FILE: test/elements/source_test.exs
 
 defmodule SourceTest do
  use ExUnit.Case, async: false


### PR DESCRIPTION
Adds h1 header with the title of the chapter on top of each .md file. Moves the filename out of the code snippet. Introduce new way to mark a tip section (with '>' sign).