### PR TITLE
fix elixir code formatting

### DIFF
--- a/broadcasting/04_RTMP_Pipeline.md
+++ b/broadcasting/04_RTMP_Pipeline.md
@@ -70,7 +70,7 @@ The final thing that is done in the `handle_init/1` callback's implementation is
  @impl true
  def handle_init(_opts) do
  ...
- {{:ok, spec: spec, playback: :playing}, %{}}
+ { {:ok, spec: spec, playback: :playing}, %{} }
  end
 ```
 

--- a/broadcasting/10_RTSP_Pipeline.md
+++ b/broadcasting/10_RTSP_Pipeline.md
@@ -37,7 +37,7 @@ def handle_other({:rtsp_setup_complete, options}, _ctx, state) do
   ]
 
   spec = %ParentSpec{children: children, links: links}
-  {{:ok, spec: spec}, %{state | video: %{sps: options[:sps], pps: options[:pps]}}}
+  { {:ok, spec: spec}, %{state | video: %{sps: options[:sps], pps: options[:pps]}} }
 end
 ```
 
@@ -81,7 +81,7 @@ def handle_notification({:new_rtp_stream, ssrc, 96, _extensions}, :rtp, _ctx, st
       [spec: %ParentSpec{children: children, links: links}]
     end
 
-  {{:ok, actions}, Map.put(state, :rtp_started, true)}
+  { {:ok, actions}, Map.put(state, :rtp_started, true) }
 end
 ```
 


### PR DESCRIPTION
That might sounds ridiculous, but completely correct elixir syntax like: `{{:ok, action} state }}` is killing a website's markdown parser as it's trying to interprate a code inside `{{ ... }}`. We'll try to find out if there is a chance to fix it, but for know let's write it like that `{ {:ok, action}, state} }` 