### PR TITLE
Fix resolution typo in caps documentation

### DIFF
--- a/basic_pipeline/04_Caps.md
+++ b/basic_pipeline/04_Caps.md
@@ -95,7 +95,7 @@ defmodule Source do
  ...
  def handle_stopped_to_prepared(_ctx, state) do
  ...
-   { {:ok, [caps: {:output, %Formats.Raw{pixel_format: I420, framerate: 45, width: 720, height: 300} }]}, state}
+   { {:ok, [caps: {:output, %Formats.Raw{pixel_format: I420, framerate: 45, width: 720, height: 480} }]}, state}
  end
 ```
 


### PR DESCRIPTION
720x300 won't match with the specified caps