### PR TITLE
Small corrections for Bin and Dynamic Pads code examples

### DIFF
--- a/basic_pipeline_extension/02_Bin.md
+++ b/basic_pipeline_extension/02_Bin.md
@@ -34,7 +34,7 @@ defmodule Basic.Bin do
     spec = [
       child(:input, %Basic.Elements.Source{location: options.input_filename})
       |> child(:ordering_buffer, Basic.Elements.OrderingBuffer)
-      |> to(:depayloader, %Basic.Elements.Depayloader{packets_per_frame: 4}) 
+      |> child(:depayloader, %Basic.Elements.Depayloader{packets_per_frame: 4}) 
       |> bin_output(:output)
     ]
 

--- a/basic_pipeline_extension/03_DynamicPads.md
+++ b/basic_pipeline_extension/03_DynamicPads.md
@@ -41,6 +41,8 @@ The very first thing we need to do is to use the `def_input_pads` appropriately.
 ```elixir
 ...
 def_input_pad :input, 
+   demand_unit: :buffers, 
+   flow_control: :manual, 
    availability: :on_request, 
    accepted_format: %Basic.Formats.Frame{encoding: :utf8}
 ...

--- a/basic_pipeline_extension/03_DynamicPads.md
+++ b/basic_pipeline_extension/03_DynamicPads.md
@@ -41,8 +41,6 @@ The very first thing we need to do is to use the `def_input_pads` appropriately.
 ```elixir
 ...
 def_input_pad :input, 
-   demand_unit: :buffers, 
-   flow_control: :pull, 
    availability: :on_request, 
    accepted_format: %Basic.Formats.Frame{encoding: :utf8}
 ...


### PR DESCRIPTION
Noted as I was going through this area of the tutorial. It looks like [`to` became `child`](https://hexdocs.pm/membrane_core/v0-11.html#update-the-children-and-links-definition) and [`pull` became `auto` (and the default value)](https://hexdocs.pm/membrane_core/v0-11.html#update-the-children-and-links-definition).